### PR TITLE
bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     asciidoctor (2.0.10)
     asciimath (1.0.9)
-    bibtex-ruby (5.0.1)
+    bibtex-ruby (5.1.1)
       latex-decode (~> 0.0)
     camertron-eprun (1.1.1)
     cldr-plurals-runtime-rb (1.0.1)
@@ -30,7 +30,7 @@ GEM
     image_size (2.0.2)
     iso-639 (0.2.8)
     iso639 (1.3.2)
-    isodoc (1.0.13)
+    isodoc (1.0.14)
       asciimath
       html2doc (~> 0.9.0)
       htmlentities (~> 4.3.4)
@@ -51,12 +51,12 @@ GEM
     metanorma (0.3.18)
       asciidoctor
       htmlentities
-    metanorma-acme (1.3.9)
+    metanorma-acme (1.3.10)
       htmlentities (~> 4.3.4)
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
       ruby-jing
-    metanorma-cli (1.2.8.4)
+    metanorma-cli (1.2.8.5)
       git (~> 1.5)
       isodoc (~> 1.0.0)
       metanorma (~> 0.3.9)
@@ -74,7 +74,7 @@ GEM
       metanorma-standoc (~> 1.3.0)
       metanorma-unece (~> 0.2.0)
       thor (~> 0.20.3)
-    metanorma-csa (1.4.0)
+    metanorma-csa (1.4.1)
       htmlentities (~> 4.3.4)
       image_size
       isodoc (~> 1.0.0)
@@ -83,20 +83,20 @@ GEM
       ruby-jing
       thread_safe
       uuidtools
-    metanorma-csd (1.3.9)
+    metanorma-csd (1.3.10)
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
-    metanorma-gb (1.3.12)
+    metanorma-gb (1.3.13)
       gb-agencies (~> 0.0.4)
       htmlentities (~> 4.3.4)
       isodoc (~> 1.0.0)
       metanorma-iso (~> 1.3.0)
       twitter_cldr (~> 4.4.4)
-    metanorma-iec (0.1.4)
+    metanorma-iec (0.1.5)
       isodoc (~> 1.0.0)
       metanorma-iso (~> 1.3.0)
       ruby-jing
-    metanorma-ietf (2.0.1)
+    metanorma-ietf (2.0.2)
       isodoc (~> 1.0.0)
       mathml2asciimath
       metanorma-standoc (~> 1.3.0)
@@ -104,12 +104,12 @@ GEM
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
       ruby-jing
-    metanorma-itu (1.0.4)
+    metanorma-itu (1.0.5)
       htmlentities (~> 4.3.4)
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
       ruby-jing
-    metanorma-m3d (1.3.9)
+    metanorma-m3d (1.3.10)
       asciimath
       htmlentities (~> 4.3.4)
       image_size
@@ -119,20 +119,20 @@ GEM
       ruby-jing
       thread_safe
       uuidtools
-    metanorma-nist (0.2.11)
+    metanorma-nist (0.2.12)
       htmlentities (~> 4.3.4)
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
       ruby-jing
       twitter_cldr
       tzinfo-data
-    metanorma-ogc (0.2.10)
+    metanorma-ogc (0.2.11)
       htmlentities (~> 4.3.4)
       iso-639
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
       ruby-jing
-    metanorma-standoc (1.3.13)
+    metanorma-standoc (1.3.14)
       asciidoctor (~> 2.0.0)
       concurrent-ruby
       html2doc (~> 0.9.0)
@@ -144,7 +144,7 @@ GEM
       ruby-jing
       sterile (~> 1.0.14)
       unicode2latex (~> 0.0.1)
-    metanorma-unece (0.2.11)
+    metanorma-unece (0.2.12)
       htmlentities (~> 4.3.4)
       iso-639
       isodoc (~> 1.0.0)
@@ -200,7 +200,7 @@ GEM
       ruby_deep_clone (~> 0.8.0)
     relaton-itu (0.5.0)
       relaton-iso-bib (~> 0.5.0)
-    relaton-nist (0.5.0)
+    relaton-nist (0.5.1)
       relaton-bib (~> 0.5.0)
       rubyzip
     relaton-ogc (0.3.0)


### PR DESCRIPTION
    Fetching metanorma-standoc 1.3.13
    Downloading metanorma-standoc-1.3.13 revealed dependencies
    not in the API or the lockfile (relaton (~> 0.6.0)).
    Either installing with `--full-index` or running `bundle update
    metanorma-standoc` should fix the problem.